### PR TITLE
EOE, FOE and other (thread-safety) fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,14 +86,14 @@ BUILT_SOURCES = \
 	ethercat.spec
 
 modules:
-	$(MAKE) -C "$(LINUX_SOURCE_DIR)" M="@abs_srcdir@" modules
+	$(MAKE) -C "$(LINUX_SOURCE_DIR)" $(LINUX_EXTRA) M="@abs_srcdir@" modules
 
 modules_install:
-	$(MAKE) -C "$(LINUX_SOURCE_DIR)" M="@abs_srcdir@" \
-		INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)" modules_install
+	$(MAKE) -C "$(LINUX_SOURCE_DIR)" $(LINUX_EXTRA) M="@abs_srcdir@" \
+		INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)" $(LINUX_EXTRA) modules_install
 
 clean-local:
-	$(MAKE) -C "$(LINUX_SOURCE_DIR)" M="@abs_srcdir@" clean
+	$(MAKE) -C "$(LINUX_SOURCE_DIR)" $(LINUX_EXTRA) M="@abs_srcdir@" clean
 
 mydist:
 	hg log --style=changelog $(srcdir) > ChangeLog

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,18 @@ AC_ARG_WITH([linux-dir],
     ]
 )
 
+AC_ARG_WITH([linux-extra],
+    AC_HELP_STRING(
+        [--with-linux-extra=<extra_kernel_makefile_args>]
+    ),
+    [
+        linux_extraargs=[$withval]
+    ],
+    [
+        linux_extraargs=
+    ]
+)
+
 AC_MSG_CHECKING([for Linux kernel sources])
 
 if test \! -r ${sourcedir}/.config; then
@@ -147,6 +159,7 @@ linuxversion=`echo $kernelrelease | grep -oE "$regex"`
 
 AC_SUBST(LINUX_SOURCE_DIR,[$sourcedir])
 AC_MSG_RESULT([$LINUX_SOURCE_DIR (Kernel $linuxversion)])
+AC_SUBST(LINUX_EXTRA,[$linux_extraargs])
 
 fi
 

--- a/master/ethernet.c
+++ b/master/ethernet.c
@@ -1298,6 +1298,7 @@ int ec_eoedev_tx(struct sk_buff *skb, /**< transmit socket buffer */
         EC_SLAVE_WARN(eoe->slave, "EoE TX frame (%u octets)"
                 " exceeds MTU. dropping.\n", skb->len);
         eoe->stats.tx_dropped++;
+        spin_unlock_bh( &eoe->tx_lock );
         dev_kfree_skb(skb);
         return 0;
     }

--- a/master/ethernet.c
+++ b/master/ethernet.c
@@ -627,7 +627,7 @@ int ec_eoe_send(ec_eoe_t *eoe /**< EoE handler */)
     {
     unsigned queued_frames;
     spin_lock_bh( &eoe->tx_lock );
-        queued_frames = ec_eoe_tx_queued_frames(eoe);
+    queued_frames = ec_eoe_tx_queued_frames(eoe);
     spin_unlock_bh( &eoe->tx_lock );
     EC_SLAVE_DBG(eoe->slave, 0, "EoE %s TX sending fragment %u%s"
             " with %zu octets (%zu). %u frames queued.\n",
@@ -1050,9 +1050,9 @@ void ec_eoe_state_tx_start(ec_eoe_t *eoe /**< EoE handler */)
             eoe->tx_queue_active = 1;
             netif_wake_queue(eoe->dev);
         }
+        spin_unlock_bh(&eoe->tx_lock);
 
         eoe->tx_idle = 1;
-        spin_unlock_bh(&eoe->tx_lock);
         // no data available.
         // start a new receive immediately.
         ec_eoe_state_rx_start(eoe);
@@ -1288,7 +1288,7 @@ int ec_eoedev_tx(struct sk_buff *skb, /**< transmit socket buffer */
 
         if (skb) {
             dev_kfree_skb(skb);
-		}
+        }
         
         return NETDEV_TX_OK;
     }
@@ -1343,7 +1343,7 @@ struct net_device_stats *ec_eoedev_stats(
         )
 {
     ec_eoe_t *eoe = *((ec_eoe_t **) netdev_priv(dev));
-    /* BUG: unprotected stats */
+    /* NOTE: stats not protected by locking */
     return &eoe->stats;
 }
 

--- a/master/ethernet.c
+++ b/master/ethernet.c
@@ -251,6 +251,8 @@ int ec_eoe_init(
     eoe->rx_idle = 1;
     eoe->tx_idle = 1;
 
+    spin_lock_init(&eoe->tx_lock);
+
     /* device name eoe<MASTER>[as]<SLAVE>, because networking scripts don't
      * like hyphens etc. in interface names. */
     if (alias) {
@@ -353,6 +355,10 @@ int ec_eoe_init(
     priv = netdev_priv(eoe->dev);
     *priv = eoe;
 
+    // set carrier off status BEFORE open */
+    EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", eoe->dev->name);
+    netif_carrier_off(eoe->dev);
+
     // connect the net_device to the kernel
     ret = register_netdev(eoe->dev);
     if (ret) {
@@ -360,10 +366,6 @@ int ec_eoe_init(
                 " error %i\n", eoe->dev->name, ret);
         goto out_free;
     }
-
-    // set carrier off status BEFORE open */
-    EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", eoe->dev->name);
-    netif_carrier_off(eoe->dev);
 
     return 0;
 
@@ -414,12 +416,12 @@ void ec_eoe_link_slave(
         ec_slave_t *slave /**< EtherCAT slave */
         )
 {
+
+    spin_lock_bh( &eoe->tx_lock );
+
     eoe->slave = slave;
 
     if (eoe->slave) {
-        EC_SLAVE_INFO(slave, "Linked to EoE handler %s\n",
-                eoe->dev->name);
-
         // Usually setting the MTU appropriately makes the upper layers
         // do the frame fragmenting. In some cases this doesn't work
         // so the MTU is left on the Ethernet standard value and fragmenting
@@ -427,14 +429,19 @@ void ec_eoe_link_slave(
 #if 0
         eoe->dev->mtu = slave->configured_rx_mailbox_size - ETH_HLEN - 10;
 #endif
+        netif_carrier_on(eoe->dev);
+        spin_unlock_bh( &eoe->tx_lock );
+
+        EC_SLAVE_INFO(slave, "Linked to EoE handler %s\n",
+                eoe->dev->name);
 
         EC_MASTER_DBG(eoe->master, 1, "%s: carrier on.\n", eoe->dev->name);
-        netif_carrier_on(eoe->dev);
     } else {
+        netif_carrier_off(eoe->dev);
+        spin_unlock_bh( &eoe->tx_lock );
         EC_MASTER_ERR(eoe->master, "%s : slave not supplied to ec_eoe_link_slave().\n",
                 eoe->dev->name);
         EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", eoe->dev->name);
-        netif_carrier_off(eoe->dev);
     }
 }
 
@@ -452,7 +459,11 @@ void ec_eoe_clear_slave(ec_eoe_t *eoe /**< EoE handler */)
 #endif
 
     EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", eoe->dev->name);
+
+    spin_lock_bh( &eoe->tx_lock );
     netif_carrier_off(eoe->dev);
+    eoe->slave = NULL;
+    spin_unlock_bh( &eoe->tx_lock );
 
     // empty transmit queue
     ec_eoe_flush(eoe);
@@ -471,8 +482,6 @@ void ec_eoe_clear_slave(ec_eoe_t *eoe /**< EoE handler */)
 
     eoe->state = ec_eoe_state_rx_start;
         
-    eoe->slave = NULL;
-
 #if EOE_DEBUG_LEVEL >= 1
     if (slave) {
         EC_MASTER_DBG(eoe->master, 0, "%s slave link cleared.\n", eoe->dev->name);
@@ -484,7 +493,9 @@ void ec_eoe_clear_slave(ec_eoe_t *eoe /**< EoE handler */)
 
 /** EoE destructor.
  *
- * Unregisteres the net_device and frees allocated memory.
+ * Unregisters the net_device and frees allocated memory.
+ *
+ * Caller MUST NOT hold 'master_sem'!
  */
 void ec_eoe_clear(ec_eoe_t *eoe /**< EoE handler */)
 {
@@ -509,6 +520,10 @@ void ec_eoe_clear(ec_eoe_t *eoe /**< EoE handler */)
 /*****************************************************************************/
 
 /** Empties the transmit queue.
+ *
+ * Caller must ensure eoe->slave == NULL or netif_carrier_off() in order
+ * to prevent a softirq handler from accessing the ring we are flushing.
+ *
  */
 void ec_eoe_flush(ec_eoe_t *eoe /**< EoE handler */)
 {
@@ -537,6 +552,9 @@ void ec_eoe_flush(ec_eoe_t *eoe /**< EoE handler */)
 
 /*****************************************************************************/
 
+/*
+ * Caller must hold tx_lock
+ */
 unsigned int ec_eoe_tx_queued_frames(const ec_eoe_t *eoe /**< EoE handler */)
 {
     unsigned int next_to_use = eoe->tx_next_to_use;
@@ -551,6 +569,9 @@ unsigned int ec_eoe_tx_queued_frames(const ec_eoe_t *eoe /**< EoE handler */)
 
 /*****************************************************************************/
 
+/*
+ * Caller must hold tx_lock
+ */
 static unsigned int eoe_tx_unused_frames(ec_eoe_t *eoe /**< EoE handler */)
 {
     unsigned int next_to_use = eoe->tx_next_to_use;
@@ -603,11 +624,17 @@ int ec_eoe_send(ec_eoe_t *eoe /**< EoE handler */)
     }
 
 #if EOE_DEBUG_LEVEL >= 2
+    {
+    unsigned queued_frames;
+    spin_lock_bh( &eoe->tx_lock );
+        queued_frames = ec_eoe_tx_queued_frames(eoe);
+    spin_unlock_bh( &eoe->tx_lock );
     EC_SLAVE_DBG(eoe->slave, 0, "EoE %s TX sending fragment %u%s"
             " with %zu octets (%zu). %u frames queued.\n",
             eoe->dev->name, eoe->tx_fragment_number,
             last_fragment ? "" : "+", current_size, complete_offset,
-            ec_eoe_tx_queued_frames(eoe));
+            queued_frames);
+    }
 #endif
 
 #if EOE_DEBUG_LEVEL >= 3
@@ -1015,6 +1042,8 @@ void ec_eoe_state_tx_start(ec_eoe_t *eoe /**< EoE handler */)
         return;
     }
 
+    spin_lock_bh(&eoe->tx_lock);
+
     if (eoe->tx_next_to_use == eoe->tx_next_to_clean) {
         // check if the queue needs to be restarted
         if (!eoe->tx_queue_active) {
@@ -1023,6 +1052,7 @@ void ec_eoe_state_tx_start(ec_eoe_t *eoe /**< EoE handler */)
         }
 
         eoe->tx_idle = 1;
+        spin_unlock_bh(&eoe->tx_lock);
         // no data available.
         // start a new receive immediately.
         ec_eoe_state_rx_start(eoe);
@@ -1045,6 +1075,8 @@ void ec_eoe_state_tx_start(ec_eoe_t *eoe /**< EoE handler */)
         wakeup = 1;
 #endif
     }
+
+    spin_unlock_bh(&eoe->tx_lock);
 
     eoe->tx_idle = 0;
 
@@ -1146,6 +1178,23 @@ void ec_eoe_state_tx_sent(ec_eoe_t *eoe /**< EoE handler */)
  *  NET_DEVICE functions
  *****************************************************************************/
 
+/* Synchronization notes:
+ *  - anyone may open/close the network device; we must thus synchronize with
+ *    the 'master_sem'.
+ *  - this is complicated by the fact that 'ec_eoedev_stop()' can be called
+ *    via 'unregister_netdev()' from 'ec_eoe_clear()'. To avoid deadlock
+ *    'ec_eoe_clear()' must not be called with 'master_sem' already locked!
+ *  - other threads but also softirqs may call 'ec_eoedev_tx()'. We introduce
+ *    the 'tx_lock' spinlock to protect the tx ring and associated pointers and
+ *    flags.
+ *  - the tx ring may be safely manipulated ('ec_eoe_flush()') if the caller of
+ *    'ec_eoe_flush()' ensures that 'netif_carrier_off()' or 'eoe->slave == NULL'.
+ *    This prevents 'ec_eoedev_tx()' from accessing the ring. It may still be
+ *    necessary to synchronize with threads using 'master_sem'.
+ *  - statistics and MAC address unprotected ('ec_eoedev_set_mac()',
+ *    'ec_eoedev_stats()')
+ */
+
 /** Opens the virtual network device.
  *
  * \return Always zero (success).
@@ -1154,15 +1203,20 @@ int ec_eoedev_open(struct net_device *dev /**< EoE net_device */)
 {
     ec_eoe_t *eoe = *((ec_eoe_t **) netdev_priv(dev));
 
+    ec_lock_down( &eoe->master->master_sem );
+
     // set carrier to off until we know link status
     EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", dev->name);
+
+    spin_lock_bh( &eoe->tx_lock );
     netif_carrier_off(dev);
+    eoe->tx_queue_active = 1;
+    spin_unlock_bh( &eoe->tx_lock );
 
     ec_eoe_flush(eoe);
     eoe->opened = 1;
     eoe->rx_idle = 0;
     eoe->tx_idle = 0;
-    eoe->tx_queue_active = 1;
     netif_start_queue(dev);
 #if EOE_DEBUG_LEVEL >= 2
     EC_MASTER_DBG(eoe->master, 0, "%s opened.\n", dev->name);
@@ -1171,8 +1225,13 @@ int ec_eoedev_open(struct net_device *dev /**< EoE net_device */)
     // update carrier link status
     if (eoe->slave) {
         EC_MASTER_DBG(eoe->master, 1, "%s: carrier on.\n", dev->name);
+        /* no need for acquiring tx_lock - netif_carrier_on is an atomic operation
+         * and we have no local data to synchronize
+         */
         netif_carrier_on(dev);
     }
+
+    ec_lock_up( &eoe->master->master_sem );
 
     return 0;
 }
@@ -1187,10 +1246,15 @@ int ec_eoedev_stop(struct net_device *dev /**< EoE net_device */)
 {
     ec_eoe_t *eoe = *((ec_eoe_t **) netdev_priv(dev));
     
+    ec_lock_down( &eoe->master->master_sem );
     EC_MASTER_DBG(eoe->master, 1, "%s: carrier off.\n", dev->name);
+
+    spin_lock_bh( &eoe->tx_lock );
     netif_carrier_off(dev);
-    netif_stop_queue(dev);
     eoe->tx_queue_active = 0;
+    spin_unlock_bh( &eoe->tx_lock );
+
+    netif_stop_queue(dev);
     eoe->rx_idle = 1;
     eoe->tx_idle = 1;
     eoe->opened = 0;
@@ -1198,6 +1262,7 @@ int ec_eoedev_stop(struct net_device *dev /**< EoE net_device */)
 #if EOE_DEBUG_LEVEL >= 2
     EC_MASTER_DBG(eoe->master, 0, "%s stopped.\n", dev->name);
 #endif
+    ec_lock_up( &eoe->master->master_sem );
     return 0;
 }
 
@@ -1213,11 +1278,17 @@ int ec_eoedev_tx(struct sk_buff *skb, /**< transmit socket buffer */
 {
     ec_eoe_t *eoe = *((ec_eoe_t **) netdev_priv(dev));
 
-    if (!eoe->slave) {
+    spin_lock_bh( &eoe->tx_lock );
+
+    if (!eoe->slave || !netif_carrier_ok(eoe->dev)) {
         if (skb) {
-            dev_kfree_skb(skb);
             eoe->stats.tx_dropped++;
         }
+        spin_unlock_bh( &eoe->tx_lock );
+
+        if (skb) {
+            dev_kfree_skb(skb);
+		}
         
         return NETDEV_TX_OK;
     }
@@ -1226,8 +1297,8 @@ int ec_eoedev_tx(struct sk_buff *skb, /**< transmit socket buffer */
     if (skb->len > eoe->slave->configured_tx_mailbox_size - 10) {
         EC_SLAVE_WARN(eoe->slave, "EoE TX frame (%u octets)"
                 " exceeds MTU. dropping.\n", skb->len);
-        dev_kfree_skb(skb);
         eoe->stats.tx_dropped++;
+        dev_kfree_skb(skb);
         return 0;
     }
 #endif
@@ -1255,6 +1326,8 @@ int ec_eoedev_tx(struct sk_buff *skb, /**< transmit socket buffer */
     }
 #endif
 
+    spin_unlock_bh( &eoe->tx_lock );
+
     return 0;
 }
 
@@ -1269,6 +1342,7 @@ struct net_device_stats *ec_eoedev_stats(
         )
 {
     ec_eoe_t *eoe = *((ec_eoe_t **) netdev_priv(dev));
+    /* BUG: unprotected stats */
     return &eoe->stats;
 }
 

--- a/master/ethernet.h
+++ b/master/ethernet.h
@@ -106,6 +106,8 @@ struct ec_eoe
     unsigned int tx_idle; /**< Idle flag. */
 
     unsigned int tries; /**< Tries. */
+
+    spinlock_t   tx_lock; /**< Protect slave, tx_ring, tx_next_to_use, tx_next_to_clean, tx_ring_count, tx_queue_active from BH */
 };
 
 /*****************************************************************************/

--- a/master/fsm_eoe.c
+++ b/master/fsm_eoe.c
@@ -195,6 +195,7 @@ int ec_fsm_eoe_prepare_set(
     }
     cur += ETH_ALEN;
 
+	/* NOTE: the tool already provides addresses in network-byte order */
     if (req->ip_address_included) {
         uint32_t swapped = req->ip_address;
         memcpy(cur, &swapped, 4);

--- a/master/fsm_eoe.c
+++ b/master/fsm_eoe.c
@@ -196,25 +196,25 @@ int ec_fsm_eoe_prepare_set(
     cur += ETH_ALEN;
 
     if (req->ip_address_included) {
-        uint32_t swapped = htonl(req->ip_address);
+        uint32_t swapped = req->ip_address;
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->subnet_mask_included) {
-        uint32_t swapped = htonl(req->subnet_mask);
+        uint32_t swapped = req->subnet_mask;
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->gateway_included) {
-        uint32_t swapped = htonl(req->gateway);
+        uint32_t swapped = req->gateway;
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->dns_included) {
-        uint32_t swapped = htonl(req->dns);
+        uint32_t swapped = req->dns;
         memcpy(cur, &swapped, 4);
     }
     cur += 4;

--- a/master/fsm_eoe.c
+++ b/master/fsm_eoe.c
@@ -197,25 +197,25 @@ int ec_fsm_eoe_prepare_set(
 
     /* NOTE: the tool already provides addresses in network-byte order */
     if (req->ip_address_included) {
-        uint32_t swapped = req->ip_address;
+        uint32_t swapped = htonl(req->ip_address);
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->subnet_mask_included) {
-        uint32_t swapped = req->subnet_mask;
+        uint32_t swapped = htonl(req->subnet_mask);
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->gateway_included) {
-        uint32_t swapped = req->gateway;
+        uint32_t swapped = htonl(req->gateway);
         memcpy(cur, &swapped, 4);
     }
     cur += 4;
 
     if (req->dns_included) {
-        uint32_t swapped = req->dns;
+        uint32_t swapped = htonl(req->dns);
         memcpy(cur, &swapped, 4);
     }
     cur += 4;

--- a/master/fsm_eoe.c
+++ b/master/fsm_eoe.c
@@ -195,7 +195,7 @@ int ec_fsm_eoe_prepare_set(
     }
     cur += ETH_ALEN;
 
-	/* NOTE: the tool already provides addresses in network-byte order */
+    /* NOTE: the tool already provides addresses in network-byte order */
     if (req->ip_address_included) {
         uint32_t swapped = req->ip_address;
         memcpy(cur, &swapped, 4);

--- a/master/fsm_foe.c
+++ b/master/fsm_foe.c
@@ -219,7 +219,7 @@ int ec_foe_prepare_data_send(
     uint8_t *data;
 
     remaining_size = fsm->buffer_size - fsm->buffer_offset;
-    current_size = fsm->slave->configured_tx_mailbox_size
+    current_size = fsm->slave->configured_rx_mailbox_size
             - EC_MBOX_HEADER_SIZE - EC_FOE_HEADER_SIZE;
 
     if (remaining_size < current_size) {

--- a/master/fsm_foe.c
+++ b/master/fsm_foe.c
@@ -219,7 +219,7 @@ int ec_foe_prepare_data_send(
     uint8_t *data;
 
     remaining_size = fsm->buffer_size - fsm->buffer_offset;
-    current_size = fsm->slave->configured_rx_mailbox_size
+    current_size = fsm->slave->configured_tx_mailbox_size
             - EC_MBOX_HEADER_SIZE - EC_FOE_HEADER_SIZE;
 
     if (remaining_size < current_size) {

--- a/master/ioctl.c
+++ b/master/ioctl.c
@@ -2413,17 +2413,17 @@ static ATTRIBUTES int ec_ioctl_send(
     up( & master->io_sem );
 #else
     if (master->send_cb != NULL) {
-		/* The internal_callback was installed by the 'activate' ioctl.
-		 * this already uses the io_sem for synchronization with the
-		 * EoE thread. T.S., 2/2022
-		 */
+        /* The internal_callback was installed by the 'activate' ioctl.
+         * this already uses the io_sem for synchronization with the
+         * EoE thread. T.S., 2/2022
+         */
         master->send_cb(master->cb_data);
         sent_bytes = 0;
     } else {
-		down( & master->io_sem );
-		sent_bytes = ecrt_master_send(master);
-		up( & master->io_sem );
-	}
+        down( & master->io_sem );
+        sent_bytes = ecrt_master_send(master);
+        up( & master->io_sem );
+    }
 #endif
 
     ec_ioctl_lock_up(&master->master_sem);
@@ -2462,16 +2462,16 @@ static ATTRIBUTES int ec_ioctl_receive(
     up( & master->io_sem );
 #else
     if (master->receive_cb != NULL)
-		/* The internal_callback was installed by the 'activate' ioctl.
-		 * this already uses the io_sem for synchronization with the
-		 * EoE thread. T.S., 2/2022
-		 */
-	     master->receive_cb(master->cb_data);
+        /* The internal_callback was installed by the 'activate' ioctl.
+         * this already uses the io_sem for synchronization with the
+         * EoE thread. T.S., 2/2022
+         */
+        master->receive_cb(master->cb_data);
     else {
-		down( & master->io_sem );
+        down( & master->io_sem );
         ecrt_master_receive(master);
-		up( & master->io_sem );
-	}
+        up( & master->io_sem );
+    }
 #endif
 
     ec_ioctl_lock_up(&master->master_sem);

--- a/master/ioctl.c
+++ b/master/ioctl.c
@@ -2601,7 +2601,9 @@ static ATTRIBUTES int ec_ioctl_sync_ref(
         return -EPERM;
     }
 
+    down( & master->io_sem );
     ecrt_master_sync_reference_clock(master);
+    up( & master->io_sem );
     return 0;
 }
 
@@ -2626,7 +2628,9 @@ static ATTRIBUTES int ec_ioctl_sync_ref_to(
         return -EFAULT;
     }
 
+    down( & master->io_sem );
     ecrt_master_sync_reference_clock_to(master, time);
+    up( & master->io_sem );
     return 0;
 }
 
@@ -2646,7 +2650,9 @@ static ATTRIBUTES int ec_ioctl_sync_slaves(
         return -EPERM;
     }
 
+    down( & master->io_sem );
     ecrt_master_sync_slave_clocks(master);
+    up( & master->io_sem );
     return 0;
 }
 
@@ -2748,7 +2754,10 @@ static ATTRIBUTES int ec_ioctl_sync_mon_queue(
         return -EPERM;
     }
 
+    down( & master->io_sem );
     ecrt_master_sync_monitor_queue(master);
+    up( & master->io_sem );
+
     return 0;
 }
 
@@ -3910,7 +3919,9 @@ static ATTRIBUTES int ec_ioctl_domain_queue(
         return -ENOENT;
     }
 
+    down( & master->io_sem );
     ecrt_domain_queue(domain);
+    up( & master->io_sem );
 
     ec_ioctl_lock_up(&master->master_sem);
 
@@ -4928,7 +4939,9 @@ static ATTRIBUTES int ec_ioctl_voe_exec(
         return -ENOENT;
     }
 
+    down( & master->io_sem );
     data.state = ecrt_voe_handler_execute(voe);
+    up( & master->io_sem );
     if (data.state == EC_REQUEST_SUCCESS && voe->dir == EC_DIR_INPUT)
         data.size = ecrt_voe_handler_data_size(voe);
     else

--- a/master/ioctl.c
+++ b/master/ioctl.c
@@ -2495,7 +2495,9 @@ static ATTRIBUTES int ec_ioctl_send_ext(
         return -EPERM;
     }
 
+    down( & master->io_sem );
     sent_bytes = ecrt_master_send_ext(master);
+    up( & master->io_sem );
 
     if (copy_to_user((void __user *) arg, &sent_bytes, sizeof(sent_bytes))) {
         return -EFAULT;
@@ -2703,7 +2705,9 @@ static ATTRIBUTES int ec_ioctl_64bit_ref_clock_time_queue(
         return -EPERM;
     }
 
+    down( & master->io_sem );
     ecrt_master_64bit_reference_clock_time_queue(master);
+    up( & master->io_sem );
     return 0;
 }
 

--- a/master/ioctl.c
+++ b/master/ioctl.c
@@ -2407,6 +2407,11 @@ static ATTRIBUTES int ec_ioctl_send(
     if (ec_ioctl_lock_down_interruptible(&master->master_sem))
         return -EINTR;
 
+	/* Must take the io_sem to synchronize with EoE thread; the
+     * EoE thread does not hold master_sem when executing the send_cb
+	 */
+    down( & master->io_sem );
+
 #if defined(EC_RTDM) && defined(EC_EOE)
     sent_bytes = ecrt_master_send(master);
 #else
@@ -2416,6 +2421,8 @@ static ATTRIBUTES int ec_ioctl_send(
     } else
         sent_bytes = ecrt_master_send(master);
 #endif
+
+    up( & master->io_sem );
 
     ec_ioctl_lock_up(&master->master_sem);
 
@@ -2447,6 +2454,11 @@ static ATTRIBUTES int ec_ioctl_receive(
     if (ec_ioctl_lock_down_interruptible(&master->master_sem))
         return -EINTR;
 
+	/* Must take the io_sem to synchronize with EoE thread; the
+     * EoE thread does not hold master_sem when executing the receive_cb
+	 */
+    down( & master->io_sem );
+
 #if defined(EC_RTDM) && defined(EC_EOE)
     ecrt_master_receive(master);
 #else
@@ -2455,6 +2467,8 @@ static ATTRIBUTES int ec_ioctl_receive(
     else
         ecrt_master_receive(master);
 #endif
+
+    up( & master->io_sem );
 
     ec_ioctl_lock_up(&master->master_sem);
 

--- a/master/master.c
+++ b/master/master.c
@@ -121,17 +121,23 @@ void ec_master_update_device_stats(ec_master_t *);
 
 /** Static variables initializer.
 */
-void ec_master_init_static(void)
+void ec_master_init_static(unsigned long ec_io_timeout, unsigned long ec_sdo_injection_timeout)
 {
+    if ( ec_io_timeout < EC_IO_TIMEOUT ) {
+        ec_io_timeout = EC_IO_TIMEOUT;
+    }
+    if ( ec_sdo_injection_timeout < EC_SDO_INJECTION_TIMEOUT ) {
+        ec_sdo_injection_timeout = EC_SDO_INJECTION_TIMEOUT;
+    }
 #ifdef EC_HAVE_CYCLES
-    timeout_cycles = (cycles_t) EC_IO_TIMEOUT /* us */ * (cpu_khz / 1000);
+    timeout_cycles = (cycles_t) ec_io_timeout /* us */ * (cpu_khz / 1000);
     ext_injection_timeout_cycles =
-        (cycles_t) EC_SDO_INJECTION_TIMEOUT /* us */ * (cpu_khz / 1000);
+        (cycles_t) ec_sdo_injection_timeout /* us */ * (cpu_khz / 1000);
 #else
     // one jiffy may always elapse between time measurement
-    timeout_jiffies = max(EC_IO_TIMEOUT * HZ / 1000000, 1);
+    timeout_jiffies = max(ec_io_timeout * HZ / 1000000, 1);
     ext_injection_timeout_jiffies =
-        max(EC_SDO_INJECTION_TIMEOUT * HZ / 1000000, 1);
+        max(ec_sdo_injection_timeout * HZ / 1000000, 1);
 #endif
 }
 

--- a/master/master.c
+++ b/master/master.c
@@ -2178,7 +2178,6 @@ static int ec_master_eoe_thread(void *priv_data)
 
     allow_signal( SIGKILL );
 
-
     while (!kthread_should_stop()) {
         none_open = 1;
         all_idle = 1;
@@ -2241,7 +2240,7 @@ schedule:
             schedule_timeout(1);
             if ( signal_pending( current ) ) {
                 /* Immediately break the loop; we'll wait for the 'kthread_stop' below;
-                 * if we didn't we would never sleep during a subsequent loop iteration
+                 * if we didn't break we would never sleep during a subsequent loop iteration
                  * because the signal remains pending.
                  */
                 __set_current_state( TASK_RUNNING );
@@ -2252,14 +2251,13 @@ schedule:
         }
     }
 
-    /* Clear and block pending signal (otherwise we'll never sleep in the loop below
-     * while the signal is pending...
+    /* Clear and block pending signal (otherwise we'll never sleep in
+     * the loop below while the signal is pending)...
      */
     disallow_signal( SIGKILL );
 
-    /* If we broke the loop because we got a signal while
-     * blocking for the master_sem we still must wait for
-     * the 'stop' flag...
+    /* If we broke the loop due to a signal then
+     * we still must wait for the 'stop' flag...
      */
     for ( ;; ) {
         set_current_state( TASK_INTERRUPTIBLE );

--- a/master/master.c
+++ b/master/master.c
@@ -117,6 +117,13 @@ void ec_master_find_dc_ref_clock(ec_master_t *);
 void ec_master_clear_device_stats(ec_master_t *);
 void ec_master_update_device_stats(ec_master_t *);
 
+static void ptsnow(void)
+{
+	struct timespec now;
+	getnstimeofday( &now );
+	printk(KERN_INFO "Time now %lu.%09lu\n", now.tv_sec, now.tv_nsec);
+}
+
 /*****************************************************************************/
 
 /** Static variables initializer.
@@ -3021,6 +3028,8 @@ void ecrt_master_deactivate(ec_master_t *master)
 
 /*****************************************************************************/
 
+static int printed = 0;
+
 size_t ecrt_master_send(ec_master_t *master)
 {
     ec_datagram_t *datagram, *n;
@@ -3059,6 +3068,10 @@ size_t ecrt_master_send(ec_master_t *master)
             ec_device_clear_stats(&master->devices[dev_idx]);
             continue;
         }
+		if ( ! printed ) {
+			ptsnow();
+			printed = 1;
+		}
 
         // send frames
         sent_bytes = max(sent_bytes,
@@ -3114,6 +3127,7 @@ void ecrt_master_receive(ec_master_t *master)
                 EC_MASTER_DBG(master, 0, "TIMED OUT datagram %p,"
                         " index %02X waited %u us.\n",
                         datagram, datagram->index, time_us);
+				ptsnow();
             }
 #endif /* RT_SYSLOG */
         }

--- a/master/master.c
+++ b/master/master.c
@@ -117,13 +117,6 @@ void ec_master_find_dc_ref_clock(ec_master_t *);
 void ec_master_clear_device_stats(ec_master_t *);
 void ec_master_update_device_stats(ec_master_t *);
 
-static void ptsnow(void)
-{
-	struct timespec now;
-	getnstimeofday( &now );
-	printk(KERN_INFO "Time now %lu.%09lu\n", now.tv_sec, now.tv_nsec);
-}
-
 /*****************************************************************************/
 
 /** Static variables initializer.
@@ -2080,10 +2073,10 @@ void ec_master_eoe_stop(ec_master_t *master /**< EtherCAT master */)
     if (master->eoe_thread) {
         EC_MASTER_INFO(master, "Stopping EoE thread.\n");
 
-		/* Send a signal - in case the caller hold the master_sem
-		 * (fsm_master); this will wake up the eoe_thread...
-		 */
-		send_sig_info( SIGKILL, SEND_SIG_PRIV, master->eoe_thread );
+        /* Send a signal - in case the caller hold the master_sem
+         * (fsm_master); this will wake up the eoe_thread...
+         */
+        send_sig_info( SIGKILL, SEND_SIG_PRIV, master->eoe_thread );
 
         kthread_stop(master->eoe_thread);
         master->eoe_thread = NULL;
@@ -2183,7 +2176,7 @@ static int ec_master_eoe_thread(void *priv_data)
 
     EC_MASTER_DBG(master, 1, "EoE thread running.\n");
 
-	allow_signal( SIGKILL );
+    allow_signal( SIGKILL );
 
 
     while (!kthread_should_stop()) {
@@ -2191,8 +2184,8 @@ static int ec_master_eoe_thread(void *priv_data)
         all_idle = 1;
 
         if ( ec_lock_down_interruptible(&master->master_sem) ) {
-			break;
-		}
+            break;
+        }
         list_for_each_entry(eoe, &master->eoe_handlers, list) {
             if (ec_eoe_is_open(eoe)) {
                 none_open = 0;
@@ -2210,8 +2203,8 @@ static int ec_master_eoe_thread(void *priv_data)
 
         // actual EoE processing
         if ( ec_lock_down_interruptible(&master->master_sem) ) {
-			break;
-		}
+            break;
+        }
         sth_to_send = 0;
         list_for_each_entry(eoe, &master->eoe_handlers, list) {
             if ( eoe->slave && 
@@ -2230,9 +2223,9 @@ static int ec_master_eoe_thread(void *priv_data)
         ec_lock_up(&master->master_sem);
 
         if (sth_to_send) {
-			if ( ec_lock_down_interruptible(&master->master_sem) ) {
-				break;
-			}
+            if ( ec_lock_down_interruptible(&master->master_sem) ) {
+                break;
+            }
             list_for_each_entry(eoe, &master->eoe_handlers, list) {
                 ec_eoe_queue(eoe);
             }
@@ -2262,20 +2255,20 @@ schedule:
     /* Clear and block pending signal (otherwise we'll never sleep in the loop below
      * while the signal is pending...
      */
-	disallow_signal( SIGKILL );
+    disallow_signal( SIGKILL );
 
-	/* If we broke the loop because we got a signal while
-	 * blocking for the master_sem we still must wait for
-	 * the 'stop' flag...
-	 */
-	for ( ;; ) {
-		set_current_state( TASK_INTERRUPTIBLE );
-		if ( kthread_should_stop() ) {
-			break;
-		}
-		schedule();
-	}
-	__set_current_state( TASK_RUNNING );
+    /* If we broke the loop because we got a signal while
+     * blocking for the master_sem we still must wait for
+     * the 'stop' flag...
+     */
+    for ( ;; ) {
+        set_current_state( TASK_INTERRUPTIBLE );
+        if ( kthread_should_stop() ) {
+            break;
+        }
+        schedule();
+    }
+    __set_current_state( TASK_RUNNING );
 
     EC_MASTER_DBG(master, 1, "EoE thread exiting...\n");
     return 0;
@@ -2887,7 +2880,7 @@ ec_domain_t *ecrt_master_create_domain(
 
 int ecrt_master_setup_domain_memory(ec_master_t *master)
 {
-	// not currently supported
+    // not currently supported
     return -ENOMEM;  // FIXME
 }
 
@@ -3065,8 +3058,6 @@ void ecrt_master_deactivate(ec_master_t *master)
 
 /*****************************************************************************/
 
-static int printed = 0;
-
 size_t ecrt_master_send(ec_master_t *master)
 {
     ec_datagram_t *datagram, *n;
@@ -3105,10 +3096,6 @@ size_t ecrt_master_send(ec_master_t *master)
             ec_device_clear_stats(&master->devices[dev_idx]);
             continue;
         }
-		if ( ! printed ) {
-			ptsnow();
-			printed = 1;
-		}
 
         // send frames
         sent_bytes = max(sent_bytes,
@@ -3164,7 +3151,6 @@ void ecrt_master_receive(ec_master_t *master)
                 EC_MASTER_DBG(master, 0, "TIMED OUT datagram %p,"
                         " index %02X waited %u us.\n",
                         datagram, datagram->index, time_us);
-				ptsnow();
             }
 #endif /* RT_SYSLOG */
         }
@@ -3514,7 +3500,7 @@ int ecrt_master_64bit_reference_clock_time(ec_master_t *master, uint64_t *time)
     }
 
     if (!master->dc_offset_valid) {
-    	return -EAGAIN;
+        return -EAGAIN;
     }
 
     // Get returned datagram time, transmission delay removed.

--- a/master/master.c
+++ b/master/master.c
@@ -135,9 +135,9 @@ void ec_master_init_static(unsigned long ec_io_timeout, unsigned long ec_sdo_inj
         (cycles_t) ec_sdo_injection_timeout /* us */ * (cpu_khz / 1000);
 #else
     // one jiffy may always elapse between time measurement
-    timeout_jiffies = max(ec_io_timeout * HZ / 1000000, 1);
+    timeout_jiffies = max(ec_io_timeout * HZ / 1000000, (unsigned long)1);
     ext_injection_timeout_jiffies =
-        max(ec_sdo_injection_timeout * HZ / 1000000, 1);
+        max(ec_sdo_injection_timeout * HZ / 1000000, (unsigned long)1);
 #endif
 }
 

--- a/master/master.c
+++ b/master/master.c
@@ -2246,10 +2246,23 @@ schedule:
         if (all_idle) {
             set_current_state(TASK_INTERRUPTIBLE);
             schedule_timeout(1);
+            if ( signal_pending( current ) ) {
+                /* Immediately break the loop; we'll wait for the 'kthread_stop' below;
+                 * if we didn't we would never sleep during a subsequent loop iteration
+                 * because the signal remains pending.
+                 */
+                __set_current_state( TASK_RUNNING );
+                break;
+            }
         } else {
             schedule();
         }
     }
+
+    /* Clear and block pending signal (otherwise we'll never sleep in the loop below
+     * while the signal is pending...
+     */
+	disallow_signal( SIGKILL );
 
 	/* If we broke the loop because we got a signal while
 	 * blocking for the master_sem we still must wait for

--- a/master/master.c
+++ b/master/master.c
@@ -1936,8 +1936,10 @@ static int ec_master_idle_thread(void *priv_data)
 
         ec_lock_up(&master->master_sem);
 
+#ifdef EC_EOE
         // cleanup eoe handers without holding master_sem
         ec_master_gc_eoe_handlers(master);
+#endif
 
         // queue and send
         ec_lock_down(&master->io_sem);
@@ -2008,8 +2010,10 @@ static int ec_master_operation_thread(void *priv_data)
 
             ec_lock_up(&master->master_sem);
 
+#ifdef EC_EOE
             // cleanup eoe handers without holding master_sem
             ec_master_gc_eoe_handlers(master);
+#endif
         }
 
 #ifdef EC_USE_HRTIMER

--- a/master/master.h
+++ b/master/master.h
@@ -342,7 +342,7 @@ struct ec_master {
 /*****************************************************************************/
 
 // static funtions
-void ec_master_init_static(void);
+void ec_master_init_static(unsigned long ec_io_timeout, unsigned long ec_sdo_injection_timeout);
 
 // master creation/deletion
 int ec_master_init(ec_master_t *, unsigned int, const uint8_t *,

--- a/master/master.h
+++ b/master/master.h
@@ -318,6 +318,7 @@ struct ec_master {
 #ifdef EC_EOE
     struct task_struct *eoe_thread; /**< EoE thread. */
     struct list_head eoe_handlers; /**< Ethernet over EtherCAT handlers. */
+    struct list_head eoe_garbage;  /**< Ethernet over EtherCAT garbage list. */
 #endif
 
     ec_lock_t io_sem; /**< Semaphore used in \a IDLE phase. */
@@ -387,6 +388,7 @@ const ec_slave_t *ec_master_find_slave_const(const ec_master_t *, uint16_t,
 void ec_master_output_stats(ec_master_t *);
 #ifdef EC_EOE
 void ec_master_clear_eoe_handlers(ec_master_t *, unsigned int);
+void ec_master_gc_eoe_handlers(ec_master_t *);
 #endif
 void ec_master_slaves_not_available(ec_master_t *);
 void ec_master_slaves_available(ec_master_t *);

--- a/master/module.c
+++ b/master/module.c
@@ -65,6 +65,8 @@ bool eoe_autocreate = 1;  /**< Auto-create EOE interfaces. */
 #endif
 static unsigned int debug_level;  /**< Debug level parameter. */
 unsigned long pcap_size;  /**< Pcap buffer size in bytes. */
+static unsigned long ec_io_timeout; /**< IO timeout in us */
+static unsigned long ec_sdo_injection_timeout; /**< SDO injection timeout in us */
 
 static ec_master_t *masters; /**< Array of masters. */
 static ec_lock_t master_sem; /**< Master semaphore. */
@@ -99,6 +101,10 @@ module_param_named(debug_level, debug_level, uint, S_IRUGO);
 MODULE_PARM_DESC(debug_level, "Debug level");
 module_param_named(pcap_size, pcap_size, ulong, S_IRUGO);
 MODULE_PARM_DESC(pcap_size, "Pcap buffer size");
+module_param_named(ec_io_timeout, ec_io_timeout, ulong, S_IRUGO);
+MODULE_PARM_DESC(ec_io_timeout, "IO timeout [us]");
+module_param_named(ec_sdo_injection_timeout, ec_sdo_injection_timeout, ulong, S_IRUGO);
+MODULE_PARM_DESC(ec_sdo_injection_timeout, "SDO injection timeout [us]");
 
 /** \endcond */
 
@@ -150,7 +156,7 @@ int __init ec_init_module(void)
     }
 
     // initialize static master variables
-    ec_master_init_static();
+    ec_master_init_static(ec_io_timeout, ec_sdo_injection_timeout);
 
     if (master_count) {
         if (!(masters = kmalloc(sizeof(ec_master_t) * master_count,


### PR DESCRIPTION
This pull-request compiles several fixes and small features:

  - FOE *fix*: `foe_prepare_data_send` used the TX instead of the RX mailbox size (RX/TX are from the perspective of the *slave*, i.e., the master posts to the so-called RX mailbox).
  - EOE *fix* - EOE lacked proper locking and was not thread safe which would lead to crashes.
  - general locking *fixes*: several `ioctl` commands failed to lock the `io_sem` and were not thread-safe.
  - *feature* add a configure (`--with-linux-extra=xxx`) option to pass arguments to the kernel module build process. This is especially useful for cross-builds. Nothing changes for a default configuration (when this option is unused).
  - *feature* made some time-outs which were hardcoded configurable as module paramters. The defaults are the previously hardcoded values.
    - timeout for injection of external datagrams
    - IO timeout